### PR TITLE
 #164410681 fixed the unregistered sender and receiver bug 

### DIFF
--- a/server/controllers/messages.js
+++ b/server/controllers/messages.js
@@ -17,6 +17,26 @@ const messages = {
     if (error) {
       res.status(400).json({ error: error.details[0].message });
     } else {
+      const trueSender = dummy.contacts.filter(sender => sender.id === senderId);
+      if (trueSender.length === 0) {
+        res.status(404).json({
+          status: 404,
+          error: "the sender is not registered",
+        });
+      }
+      const trueReceiver = dummy.contacts.filter(receiver => receiver.id === receiverId);
+      if (trueReceiver.length === 0) {
+        res.status(404).json({
+          status: 404,
+          error: "the receiver is not registered",
+        });
+      }
+      if (senderId === receiverId) {
+        res.status(400).json({
+          status: 400,
+          error: "the sender id and receiver id must not be the same",
+        });
+      }
       const id = dummy.messages.length + 1;
       const createdOn = moment().format("LL");
       const messagee = new Message(


### PR DESCRIPTION
#### What does this PR do?
It fixes the bug of sending an email from an unregistered sender and to an unregistered receiver as well as checking if the sender id is not the same as the receiver id.

#### Description of Task to be done?
It verifies if the receiver of the email is already registered and if the sender of the email is already registered. 

It also verifies if the sender ID and receiver ID are not the same prior to sending the email.

#### How should this be manually tested?
1. Start the **Server** and **POSTMAN**.
2. **Browse** the following endpoint route: **localhost:3000/api/v1/messages**.
4. Submit the required information for sending an email by indicating that the **sender ID** or **receiver ID** is above 3.
5. Check if you are given a message telling you that the sender or receiver is not registered.
6. Give the **sender ID** and **receiver ID**, a value of **1, 2, or 3**.
7. Check if you are given a message telling you that the **sender ID** and **receiver ID** must not be the same.