### PR TITLE
#164625870 fixed the duplicate email bug during registration

### DIFF
--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -23,6 +23,11 @@ const users = {
     if (error) {
       res.status(400).json({ error: error.details[0].message });
     } else {
+      for (let i = 0; i < dummy.users.length; i++) {
+        if (dummy.users[i].email === email) {
+          res.status(400).json({ status: 400, error: "the email is already taken. the user already exist. register with another unique email" });
+        }
+      }
       const id = dummy.users.length + 1;
       const user = new User(
         id, firstname, lastname, email, password,


### PR DESCRIPTION
#### What does this PR do?
It fixes the bug of registering many and indefinite times with the same email.

#### Description of Task to be done?
It verifies if the email to be registered with by the user has already been registered with and denies the registration by responding to the user that the email they are trying to use, is already used.

#### How should this be manually tested?
1. Start the **Server** and **POSTMAN**.
2. **Browse** the following endpoint route: **localhost:3000/api/v1/auth/signup**.
4. Submit the required information for registration.
5. Check if you get a message telling you that you have successfully registered.
6. Register again with the same email that you have previously used.
7. Check if you get an error message telling you that the email is already taken, that you should use another unique email to successfully register.